### PR TITLE
Feature/add get character simple report use case

### DIFF
--- a/core/data/src/main/java/com/dogeby/reliccalculator/core/data/di/DataModule.kt
+++ b/core/data/src/main/java/com/dogeby/reliccalculator/core/data/di/DataModule.kt
@@ -1,5 +1,7 @@
 package com.dogeby.reliccalculator.core.data.di
 
+import com.dogeby.reliccalculator.core.data.repository.CharacterReportRepository
+import com.dogeby.reliccalculator.core.data.repository.CharacterReportRepositoryImpl
 import com.dogeby.reliccalculator.core.data.repository.GameRepository
 import com.dogeby.reliccalculator.core.data.repository.GameRepositoryImpl
 import com.dogeby.reliccalculator.core.data.repository.PreferencesRepository
@@ -31,4 +33,10 @@ abstract class DataModule {
     @Binds
     @Singleton
     abstract fun bindsGameRepository(gameRepositoryImpl: GameRepositoryImpl): GameRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindsCharacterReportRepository(
+        characterReportRepositoryImpl: CharacterReportRepositoryImpl,
+    ): CharacterReportRepository
 }

--- a/core/data/src/main/java/com/dogeby/reliccalculator/core/data/fake/FakeCharacterReportRepository.kt
+++ b/core/data/src/main/java/com/dogeby/reliccalculator/core/data/fake/FakeCharacterReportRepository.kt
@@ -1,0 +1,67 @@
+package com.dogeby.reliccalculator.core.data.fake
+
+import com.dogeby.reliccalculator.core.data.repository.CharacterReportRepository
+import com.dogeby.reliccalculator.core.model.report.CharacterReport
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.map
+import org.jetbrains.annotations.TestOnly
+
+@TestOnly
+class FakeCharacterReportRepository : CharacterReportRepository {
+
+    private val characterReportsFlow: MutableSharedFlow<List<CharacterReport>> =
+        MutableSharedFlow<List<CharacterReport>>(
+            replay = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        ).apply {
+            tryEmit(emptyList())
+        }
+
+    override fun getAllCharacterReports(): Flow<List<CharacterReport>> {
+        return characterReportsFlow
+    }
+
+    override fun getCharacterReportsByCharacterIds(ids: Set<String>): Flow<List<CharacterReport>> {
+        return characterReportsFlow.map { reports ->
+            reports.filter { it.character.id in ids }
+        }
+    }
+
+    override fun getLatestCharacterReports(): Flow<List<CharacterReport>> {
+        return characterReportsFlow.map { reports ->
+            reports
+                .groupBy { it.character.id }
+                .mapValues { entry ->
+                    entry.value.maxByOrNull { it.generationTime }
+                }
+                .values
+                .filterNotNull()
+        }
+    }
+
+    override suspend fun insertCharacterReports(
+        reports: List<CharacterReport>,
+    ): Result<List<Long>> {
+        return Result.success(emptyList())
+    }
+
+    override suspend fun updateCharacterReports(reports: List<CharacterReport>): Result<Int> {
+        return Result.success(0)
+    }
+
+    override suspend fun upsertCharacterReports(
+        reports: List<CharacterReport>,
+    ): Result<List<Long>> {
+        return Result.success(emptyList())
+    }
+
+    override suspend fun deleteCharacterReports(reports: List<CharacterReport>): Result<Int> {
+        return Result.success(0)
+    }
+
+    fun sendCharacterReports(characterReports: List<CharacterReport>) {
+        characterReportsFlow.tryEmit(characterReports)
+    }
+}

--- a/core/data/src/main/java/com/dogeby/reliccalculator/core/data/model/CharacterReport.kt
+++ b/core/data/src/main/java/com/dogeby/reliccalculator/core/data/model/CharacterReport.kt
@@ -4,6 +4,7 @@ import com.dogeby.reliccalculator.core.database.model.report.CharacterReportEnti
 import com.dogeby.reliccalculator.core.model.report.CharacterReport
 
 fun CharacterReport.toCharacterReportEntity() = CharacterReportEntity(
+    id = id,
     characterId = character.id,
     character = character,
     preset = preset,

--- a/core/data/src/main/java/com/dogeby/reliccalculator/core/data/model/CharacterReport.kt
+++ b/core/data/src/main/java/com/dogeby/reliccalculator/core/data/model/CharacterReport.kt
@@ -1,0 +1,15 @@
+package com.dogeby.reliccalculator.core.data.model
+
+import com.dogeby.reliccalculator.core.database.model.report.CharacterReportEntity
+import com.dogeby.reliccalculator.core.model.report.CharacterReport
+
+fun CharacterReport.toCharacterReportEntity() = CharacterReportEntity(
+    characterId = character.id,
+    character = character,
+    preset = preset,
+    score = score,
+    relicReports = relicReports,
+    attrComparisonReports = attrComparisonReports,
+    validAffixCounts = validAffixCounts,
+    generationTime = generationTime,
+)

--- a/core/data/src/main/java/com/dogeby/reliccalculator/core/data/repository/CharacterReportRepository.kt
+++ b/core/data/src/main/java/com/dogeby/reliccalculator/core/data/repository/CharacterReportRepository.kt
@@ -1,0 +1,21 @@
+package com.dogeby.reliccalculator.core.data.repository
+
+import com.dogeby.reliccalculator.core.model.report.CharacterReport
+import kotlinx.coroutines.flow.Flow
+
+interface CharacterReportRepository {
+
+    fun getAllCharacterReports(): Flow<List<CharacterReport>>
+
+    fun getCharacterReportsByCharacterIds(ids: Set<String>): Flow<List<CharacterReport>>
+
+    fun getLatestCharacterReports(): Flow<List<CharacterReport>>
+
+    suspend fun insertCharacterReports(reports: List<CharacterReport>): Result<List<Long>>
+
+    suspend fun updateCharacterReports(reports: List<CharacterReport>): Result<Int>
+
+    suspend fun upsertCharacterReports(reports: List<CharacterReport>): Result<List<Long>>
+
+    suspend fun deleteCharacterReports(reports: List<CharacterReport>): Result<Int>
+}

--- a/core/data/src/main/java/com/dogeby/reliccalculator/core/data/repository/CharacterReportRepositoryImpl.kt
+++ b/core/data/src/main/java/com/dogeby/reliccalculator/core/data/repository/CharacterReportRepositoryImpl.kt
@@ -1,0 +1,65 @@
+package com.dogeby.reliccalculator.core.data.repository
+
+import com.dogeby.reliccalculator.core.data.model.toCharacterReportEntity
+import com.dogeby.reliccalculator.core.database.dao.CharacterReportDao
+import com.dogeby.reliccalculator.core.database.model.report.CharacterReportEntity
+import com.dogeby.reliccalculator.core.database.model.report.toCharacterReport
+import com.dogeby.reliccalculator.core.model.report.CharacterReport
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+@Singleton
+class CharacterReportRepositoryImpl @Inject constructor(
+    private val characterReportDao: CharacterReportDao,
+) : CharacterReportRepository {
+
+    override fun getAllCharacterReports(): Flow<List<CharacterReport>> {
+        return characterReportDao.getCharacterReports().map {
+            it.map(CharacterReportEntity::toCharacterReport)
+        }
+    }
+
+    override fun getCharacterReportsByCharacterIds(ids: Set<String>): Flow<List<CharacterReport>> {
+        return characterReportDao.getCharacterReportsByCharacterIds(ids).map {
+            it.map(CharacterReportEntity::toCharacterReport)
+        }
+    }
+
+    override fun getLatestCharacterReports(): Flow<List<CharacterReport>> {
+        return characterReportDao.getLatestCharacterReports().map {
+            it.map(CharacterReportEntity::toCharacterReport)
+        }
+    }
+
+    override suspend fun insertCharacterReports(
+        reports: List<CharacterReport>,
+    ): Result<List<Long>> = runCatching {
+        characterReportDao.insertOrIgnoreCharacterReports(
+            reports.map(CharacterReport::toCharacterReportEntity),
+        )
+    }
+
+    override suspend fun updateCharacterReports(reports: List<CharacterReport>): Result<Int> =
+        runCatching {
+            characterReportDao.updateCharacterReports(
+                reports.map(CharacterReport::toCharacterReportEntity),
+            )
+        }
+
+    override suspend fun upsertCharacterReports(
+        reports: List<CharacterReport>,
+    ): Result<List<Long>> = runCatching {
+        characterReportDao.upsertCharacterReports(
+            reports.map(CharacterReport::toCharacterReportEntity),
+        )
+    }
+
+    override suspend fun deleteCharacterReports(reports: List<CharacterReport>): Result<Int> =
+        runCatching {
+            characterReportDao.deleteCharacterReports(
+                reports.map(CharacterReport::toCharacterReportEntity),
+            )
+        }
+}

--- a/core/database/src/androidTest/java/com/dogeby/reliccalculator/core/database/CharacterReportDaoTest.kt
+++ b/core/database/src/androidTest/java/com/dogeby/reliccalculator/core/database/CharacterReportDaoTest.kt
@@ -9,6 +9,8 @@ import com.dogeby.reliccalculator.core.database.model.hoyo.sampleCharacterEntity
 import com.dogeby.reliccalculator.core.database.model.report.sampleCharacterReportEntity
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.minus
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -186,5 +188,39 @@ class CharacterReportDaoTest {
 
         Assert.assertEquals(characters.first(), result.characterEntity)
         Assert.assertEquals(characterReports, result.reports)
+    }
+
+    @Test
+    fun test_characterReportDao_getLatestCharacterReports_success() = runTest {
+        val characterReports =
+            List(3) { characterId ->
+                characterReport.copy(
+                    characterId = "$characterId",
+                    generationTime = characterReport.generationTime.minus(
+                        value = characterId,
+                        unit = DateTimeUnit.HOUR,
+                    ),
+                )
+            }
+                .run {
+                    val ids = characterReportDao.insertOrIgnoreCharacterReports(this)
+                    characterReportDao.insertOrIgnoreCharacterReports(
+                        this.map {
+                            it.copy(
+                                generationTime = it.generationTime.minus(
+                                    value = 1,
+                                    unit = DateTimeUnit.HOUR,
+                                ),
+                            )
+                        },
+                    )
+
+                    mapIndexed { index, characterReportEntity ->
+                        characterReportEntity.copy(id = ids[index].toInt())
+                    }
+                }
+
+        val result = characterReportDao.getLatestCharacterReports().first()
+        Assert.assertEquals(characterReports, result)
     }
 }

--- a/core/database/src/androidTest/java/com/dogeby/reliccalculator/core/database/CharacterReportDaoTest.kt
+++ b/core/database/src/androidTest/java/com/dogeby/reliccalculator/core/database/CharacterReportDaoTest.kt
@@ -191,6 +191,24 @@ class CharacterReportDaoTest {
     }
 
     @Test
+    fun test_characterReportDao_getCharacterReportsByCharacterIds_success() = runTest {
+        val characterReports = List(3) {
+            characterReport.copy(
+                characterId = "$it",
+            )
+        }.run {
+            val ids = characterReportDao.insertOrIgnoreCharacterReports(this)
+            mapIndexed { index, characterReportEntity ->
+                characterReportEntity.copy(id = ids[index].toInt())
+            }
+        }
+        val ids = characterReports.map { it.characterId }
+        val result = characterReportDao.getCharacterReportsByCharacterIds(ids.toSet()).first()
+
+        Assert.assertEquals(characterReports, result)
+    }
+
+    @Test
     fun test_characterReportDao_getLatestCharacterReports_success() = runTest {
         val characterReports =
             List(3) { characterId ->

--- a/core/database/src/main/java/com/dogeby/reliccalculator/core/database/dao/CharacterReportDao.kt
+++ b/core/database/src/main/java/com/dogeby/reliccalculator/core/database/dao/CharacterReportDao.kt
@@ -50,4 +50,17 @@ interface CharacterReportDao {
         """,
     )
     fun getCharactersWithReports(ids: Set<String>): Flow<List<CharacterWithReports>>
+
+    @Query(
+        value = """
+            SELECT *
+            FROM character_reports AS cr
+            WHERE cr.generationTime = (
+                SELECT MAX(sub_cr.generationTime)
+                FROM character_reports AS sub_cr
+                WHERE sub_cr.character_id = cr.character_id
+            )
+        """,
+    )
+    fun getLatestCharacterReports(): Flow<List<CharacterReportEntity>>
 }

--- a/core/database/src/main/java/com/dogeby/reliccalculator/core/database/dao/CharacterReportDao.kt
+++ b/core/database/src/main/java/com/dogeby/reliccalculator/core/database/dao/CharacterReportDao.kt
@@ -53,6 +53,14 @@ interface CharacterReportDao {
 
     @Query(
         value = """
+            SELECT * FROM character_reports
+            WHERE character_id IN (:ids)
+        """,
+    )
+    fun getCharacterReportsByCharacterIds(ids: Set<String>): Flow<List<CharacterReportEntity>>
+
+    @Query(
+        value = """
             SELECT *
             FROM character_reports AS cr
             WHERE cr.generationTime = (

--- a/core/database/src/main/java/com/dogeby/reliccalculator/core/database/model/report/CharacterReportEntity.kt
+++ b/core/database/src/main/java/com/dogeby/reliccalculator/core/database/model/report/CharacterReportEntity.kt
@@ -19,6 +19,7 @@ import com.dogeby.reliccalculator.core.model.preset.Preset
 import com.dogeby.reliccalculator.core.model.report.AffixCount
 import com.dogeby.reliccalculator.core.model.report.AffixReport
 import com.dogeby.reliccalculator.core.model.report.AttrComparisonReport
+import com.dogeby.reliccalculator.core.model.report.CharacterReport
 import com.dogeby.reliccalculator.core.model.report.RelicReport
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toInstant
@@ -45,8 +46,18 @@ data class CharacterReportEntity(
     @ColumnInfo(name = "attr_comparison_reports")
     val attrComparisonReports: List<AttrComparisonReport>,
     @ColumnInfo(name = "valid_affix_counts")
-    val validAffixCount: List<AffixCount>,
+    val validAffixCounts: List<AffixCount>,
     val generationTime: Instant,
+)
+
+fun CharacterReportEntity.toCharacterReport() = CharacterReport(
+    character = character,
+    preset = preset,
+    score = score,
+    relicReports = relicReports,
+    attrComparisonReports = attrComparisonReports,
+    validAffixCounts = validAffixCounts,
+    generationTime = generationTime,
 )
 
 @TestOnly
@@ -100,7 +111,7 @@ val sampleCharacterReportEntity = CharacterReportEntity(
             isPass = false,
         ),
     ),
-    validAffixCount = List(3) {
+    validAffixCounts = List(3) {
         AffixCount(
             type = "type$it",
             count = it,

--- a/core/database/src/main/java/com/dogeby/reliccalculator/core/database/model/report/CharacterReportEntity.kt
+++ b/core/database/src/main/java/com/dogeby/reliccalculator/core/database/model/report/CharacterReportEntity.kt
@@ -6,9 +6,16 @@ import androidx.room.PrimaryKey
 import androidx.room.TypeConverters
 import com.dogeby.reliccalculator.core.database.util.AffixCountListConverter
 import com.dogeby.reliccalculator.core.database.util.AttrComparisonReportListConverter
+import com.dogeby.reliccalculator.core.database.util.CharacterConverter
 import com.dogeby.reliccalculator.core.database.util.InstantConverter
+import com.dogeby.reliccalculator.core.database.util.PresetConverter
 import com.dogeby.reliccalculator.core.database.util.RelicReportListConverter
+import com.dogeby.reliccalculator.core.model.mihomo.Character
+import com.dogeby.reliccalculator.core.model.mihomo.Element
+import com.dogeby.reliccalculator.core.model.mihomo.LightCone
+import com.dogeby.reliccalculator.core.model.mihomo.Path
 import com.dogeby.reliccalculator.core.model.preset.ComparisonOperator
+import com.dogeby.reliccalculator.core.model.preset.Preset
 import com.dogeby.reliccalculator.core.model.report.AffixCount
 import com.dogeby.reliccalculator.core.model.report.AffixReport
 import com.dogeby.reliccalculator.core.model.report.AttrComparisonReport
@@ -23,12 +30,16 @@ import org.jetbrains.annotations.TestOnly
     AttrComparisonReportListConverter::class,
     InstantConverter::class,
     AffixCountListConverter::class,
+    CharacterConverter::class,
+    PresetConverter::class,
 )
 data class CharacterReportEntity(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "report_id")
     val id: Int = 0,
     @ColumnInfo(name = "character_id") val characterId: String,
+    val character: Character,
+    val preset: Preset,
     @ColumnInfo(name = "character_score") val score: Float,
     @ColumnInfo(name = "relic_reports") val relicReports: List<RelicReport>,
     @ColumnInfo(name = "attr_comparison_reports")
@@ -42,6 +53,27 @@ data class CharacterReportEntity(
 val sampleCharacterReportEntity = CharacterReportEntity(
     id = 0,
     characterId = "1212",
+    character = Character(
+        id = "1212",
+        name = "",
+        icon = "",
+        preview = "",
+        portrait = "",
+        path = Path("", "", ""),
+        element = Element("", "", ""),
+        lightCone = LightCone("", "", "", ""),
+        relics = emptyList(),
+        relicSets = emptyList(),
+        attributes = emptyList(),
+        additions = emptyList(),
+    ),
+    preset = Preset(
+        characterId = "1212",
+        emptyList(),
+        emptyMap(),
+        emptyList(),
+        attrComparisons = emptyList(),
+    ),
     score = 5.0f,
     relicReports = List(3) { index ->
         RelicReport(

--- a/core/database/src/main/java/com/dogeby/reliccalculator/core/database/model/report/CharacterReportEntity.kt
+++ b/core/database/src/main/java/com/dogeby/reliccalculator/core/database/model/report/CharacterReportEntity.kt
@@ -51,6 +51,7 @@ data class CharacterReportEntity(
 )
 
 fun CharacterReportEntity.toCharacterReport() = CharacterReport(
+    id = id,
     character = character,
     preset = preset,
     score = score,

--- a/core/database/src/main/java/com/dogeby/reliccalculator/core/database/util/Converters.kt
+++ b/core/database/src/main/java/com/dogeby/reliccalculator/core/database/util/Converters.kt
@@ -2,12 +2,14 @@ package com.dogeby.reliccalculator.core.database.util
 
 import androidx.room.TypeConverter
 import com.dogeby.reliccalculator.core.model.mihomo.Attribute
+import com.dogeby.reliccalculator.core.model.mihomo.Character
 import com.dogeby.reliccalculator.core.model.mihomo.Relic
 import com.dogeby.reliccalculator.core.model.mihomo.RelicSet
 import com.dogeby.reliccalculator.core.model.mihomo.index.AffixInfo
 import com.dogeby.reliccalculator.core.model.mihomo.index.RelicPiece
 import com.dogeby.reliccalculator.core.model.preset.AffixWeight
 import com.dogeby.reliccalculator.core.model.preset.AttrComparison
+import com.dogeby.reliccalculator.core.model.preset.Preset
 import com.dogeby.reliccalculator.core.model.report.AffixCount
 import com.dogeby.reliccalculator.core.model.report.AttrComparisonReport
 import com.dogeby.reliccalculator.core.model.report.RelicReport
@@ -126,4 +128,22 @@ class AffixInfoMapConverter {
 
     @TypeConverter
     fun stringToAffixInfoMap(json: String) = Json.decodeFromString<Map<String, AffixInfo>>(json)
+}
+
+class CharacterConverter {
+
+    @TypeConverter
+    fun characterToString(character: Character) = Json.encodeToString(character)
+
+    @TypeConverter
+    fun stringToCharacter(json: String) = Json.decodeFromString<Character>(json)
+}
+
+class PresetConverter {
+
+    @TypeConverter
+    fun presetToString(preset: Preset) = Json.encodeToString(preset)
+
+    @TypeConverter
+    fun stringToPreset(json: String) = Json.decodeFromString<Preset>(json)
 }

--- a/core/domain/src/main/java/com/dogeby/reliccalculator/core/domain/model/CharacterSimpleReport.kt
+++ b/core/domain/src/main/java/com/dogeby/reliccalculator/core/domain/model/CharacterSimpleReport.kt
@@ -1,0 +1,19 @@
+package com.dogeby.reliccalculator.core.domain.model
+
+import kotlinx.datetime.Instant
+
+data class CharacterSimpleReport(
+    val id: String,
+    val name: String,
+    val icon: String,
+    val updatedDate: Instant,
+    val totalScore: Float,
+    val cavernRelics: List<SimpleRelicRatingReport>,
+    val planarOrnaments: List<SimpleRelicRatingReport>,
+)
+
+data class SimpleRelicRatingReport(
+    val id: String,
+    val icon: String,
+    val score: Float,
+)

--- a/core/domain/src/main/java/com/dogeby/reliccalculator/core/domain/model/CharacterSimpleReport.kt
+++ b/core/domain/src/main/java/com/dogeby/reliccalculator/core/domain/model/CharacterSimpleReport.kt
@@ -1,9 +1,11 @@
 package com.dogeby.reliccalculator.core.domain.model
 
+import com.dogeby.reliccalculator.core.model.report.RelicReport
 import kotlinx.datetime.Instant
 
 data class CharacterSimpleReport(
-    val id: String,
+    val id: Int,
+    val characterId: String,
     val name: String,
     val icon: String,
     val updatedDate: Instant,
@@ -16,4 +18,10 @@ data class SimpleRelicRatingReport(
     val id: String,
     val icon: String,
     val score: Float,
+)
+
+fun RelicReport.toSimpleRelicRatingReport(icon: String) = SimpleRelicRatingReport(
+    id = id,
+    icon = icon,
+    score = score,
 )

--- a/core/domain/src/main/java/com/dogeby/reliccalculator/core/domain/preset/GetPresetWithDetailsListUseCase.kt
+++ b/core/domain/src/main/java/com/dogeby/reliccalculator/core/domain/preset/GetPresetWithDetailsListUseCase.kt
@@ -35,14 +35,12 @@ class GetPresetWithDetailsListUseCase @Inject constructor(
             gameRepository.relicSetInfoMap,
             gameRepository.propertyInfoMap,
         ) { characterInfoWithDetailsList, relicSetInfoMap, propertyInfoMap ->
-            val isMatchingPreferences: (CharacterInfoWithDetails) -> Boolean = { details ->
-                details.characterInfo.rarity.isMatching(filteredRarities) &&
-                    details.pathInfo.id.isMatching(filteredPathIds) &&
-                    details.elementInfo.id.isMatching(filteredElementIds)
-            }
-
             val filteredCharacters = characterInfoWithDetailsList
-                .filter(isMatchingPreferences)
+                .filter { details ->
+                    details.characterInfo.rarity.isMatching(filteredRarities) &&
+                        details.pathInfo.id.isMatching(filteredPathIds) &&
+                        details.elementInfo.id.isMatching(filteredElementIds)
+                }
                 .associateBy { it.characterInfo.id }
 
             CharacterFilterResults(
@@ -119,26 +117,12 @@ class GetPresetWithDetailsListUseCase @Inject constructor(
         characterSortField: CharacterSortField,
     ): List<PresetWithDetails> {
         return when (characterSortField) {
-            CharacterSortField.ID_ASC -> {
-                sortedWith { o1, o2 ->
-                    o2.characterId.toAdjustedId() - o1.characterId.toAdjustedId()
-                }
-            }
-            CharacterSortField.ID_DESC -> {
-                sortedWith { o1, o2 ->
-                    o1.characterId.toAdjustedId() - o2.characterId.toAdjustedId()
-                }
-            }
-            CharacterSortField.NAME_ASC -> {
-                sortedBy {
-                    it.characterInfo.name
-                }
-            }
-            CharacterSortField.NAME_DESC -> {
-                sortedByDescending {
-                    it.characterInfo.name
-                }
-            }
+            CharacterSortField.ID_ASC -> sortedWith(compareBy { it.characterId.toAdjustedId() })
+            CharacterSortField.ID_DESC -> sortedWith(
+                compareByDescending { it.characterId.toAdjustedId() },
+            )
+            CharacterSortField.NAME_ASC -> sortedBy { it.characterInfo.name }
+            CharacterSortField.NAME_DESC -> sortedByDescending { it.characterInfo.name }
         }
     }
 

--- a/core/domain/src/main/java/com/dogeby/reliccalculator/core/domain/report/GetCharacterSimpleReportUseCase.kt
+++ b/core/domain/src/main/java/com/dogeby/reliccalculator/core/domain/report/GetCharacterSimpleReportUseCase.kt
@@ -1,0 +1,113 @@
+package com.dogeby.reliccalculator.core.domain.report
+
+import com.dogeby.reliccalculator.core.data.repository.CharacterReportRepository
+import com.dogeby.reliccalculator.core.data.repository.GameRepository
+import com.dogeby.reliccalculator.core.domain.model.CharacterSimpleReport
+import com.dogeby.reliccalculator.core.domain.model.toSimpleRelicRatingReport
+import com.dogeby.reliccalculator.core.model.mihomo.index.RelicInfo
+import com.dogeby.reliccalculator.core.model.mihomo.index.RelicPiece
+import com.dogeby.reliccalculator.core.model.preferences.CharacterSortField
+import com.dogeby.reliccalculator.core.model.report.RelicReport
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+
+class GetCharacterSimpleReportUseCase @Inject constructor(
+    private val characterReportRepository: CharacterReportRepository,
+    private val gameRepository: GameRepository,
+) {
+
+    operator fun invoke(
+        filteredRarities: Set<Int>,
+        filteredPathIds: Set<String>,
+        filteredElementIds: Set<String>,
+        sortField: CharacterSortField,
+    ): Flow<List<CharacterSimpleReport>> {
+        return combine(
+            characterReportRepository.getLatestCharacterReports(),
+            gameRepository.characterInfoWithDetailsList,
+            gameRepository.relicInfoMap,
+        ) { reports, characterInfoWithDetailsList, relicInfoMap ->
+            val filteredCharacters = characterInfoWithDetailsList
+                .filter { details ->
+                    details.characterInfo.rarity.isMatching(filteredRarities) &&
+                        details.pathInfo.id.isMatching(filteredPathIds) &&
+                        details.elementInfo.id.isMatching(filteredElementIds)
+                }
+                .associateBy { it.characterInfo.id }
+
+            reports.mapNotNull { characterReport ->
+                filteredCharacters[characterReport.character.id]?.let { details ->
+                    val (cavernRelics, planarOrnaments) = divideRelicReports(
+                        relicReports = characterReport.relicReports,
+                        relicInfoMap = relicInfoMap,
+                    )
+                    CharacterSimpleReport(
+                        id = characterReport.id,
+                        characterId = characterReport.character.id,
+                        name = details.characterInfo.name,
+                        icon = details.characterInfo.icon,
+                        updatedDate = characterReport.generationTime,
+                        totalScore = characterReport.score,
+                        cavernRelics = cavernRelics.map {
+                            it.toSimpleRelicRatingReport(relicInfoMap[it.id]?.icon ?: "")
+                        },
+                        planarOrnaments = planarOrnaments.map {
+                            it.toSimpleRelicRatingReport(relicInfoMap[it.id]?.icon ?: "")
+                        },
+                    )
+                }
+            }.sortedBy(sortField)
+        }
+    }
+
+    private fun <T> T.isMatching(list: Set<T>) = list.isEmpty() or (this in list)
+
+    private data class DividedRelicReports(
+        val cavernRelics: List<RelicReport>,
+        val planarOrnaments: List<RelicReport>,
+    )
+
+    private fun divideRelicReports(
+        relicReports: List<RelicReport>,
+        relicInfoMap: Map<String, RelicInfo>,
+    ): DividedRelicReports {
+        val cavernRelics = mutableListOf<RelicReport>()
+        val planarOrnaments = mutableListOf<RelicReport>()
+
+        for (relicReport in relicReports) {
+            when (relicInfoMap[relicReport.id]?.type) {
+                RelicPiece.HEAD, RelicPiece.HAND,
+                RelicPiece.BODY, RelicPiece.FOOT,
+                -> cavernRelics.add(
+                    relicReport,
+                )
+                RelicPiece.NECK, RelicPiece.OBJECT -> planarOrnaments.add(relicReport)
+                null -> Unit
+            }
+        }
+
+        return DividedRelicReports(cavernRelics, planarOrnaments)
+    }
+
+    private fun String.toAdjustedId(): Int =
+        toIntOrNull()?.let { if (it >= TRAILBLAZER_ID) it - TRAILBLAZER_ID else it }
+            ?: 0
+
+    private fun List<CharacterSimpleReport>.sortedBy(
+        characterSortField: CharacterSortField,
+    ): List<CharacterSimpleReport> {
+        return when (characterSortField) {
+            CharacterSortField.ID_ASC -> sortedWith(compareBy { it.characterId.toAdjustedId() })
+            CharacterSortField.ID_DESC -> sortedWith(
+                compareByDescending { it.characterId.toAdjustedId() },
+            )
+            CharacterSortField.NAME_ASC -> sortedBy { it.name }
+            CharacterSortField.NAME_DESC -> sortedByDescending { it.name }
+        }
+    }
+
+    private companion object {
+        const val TRAILBLAZER_ID = 8001
+    }
+}

--- a/core/domain/src/test/java/com/dogeby/reliccalculator/core/domain/preset/GetPresetWithDetailsListUseCaseTest.kt
+++ b/core/domain/src/test/java/com/dogeby/reliccalculator/core/domain/preset/GetPresetWithDetailsListUseCaseTest.kt
@@ -200,7 +200,7 @@ class GetPresetWithDetailsListUseCaseTest {
         gameRepository.sendCharacterInfoWithDetailsList(characterInfoWithDetails)
         preferencesRepository.setPresetListPreferencesData(
             samplePresetListPreferencesData.copy(
-                sortField = CharacterSortField.ID_ASC,
+                sortField = CharacterSortField.ID_DESC,
             ),
         )
         val listPreferences = preferencesRepository.getPresetListPreferencesData().first()
@@ -233,7 +233,7 @@ class GetPresetWithDetailsListUseCaseTest {
         gameRepository.sendCharacterInfoWithDetailsList(characterInfoWithDetails)
         preferencesRepository.setPresetListPreferencesData(
             samplePresetListPreferencesData.copy(
-                sortField = CharacterSortField.ID_DESC,
+                sortField = CharacterSortField.ID_ASC,
             ),
         )
         val listPreferences = preferencesRepository.getPresetListPreferencesData().first()

--- a/core/domain/src/test/java/com/dogeby/reliccalculator/core/domain/report/GetCharacterSimpleReportUseCaseTest.kt
+++ b/core/domain/src/test/java/com/dogeby/reliccalculator/core/domain/report/GetCharacterSimpleReportUseCaseTest.kt
@@ -1,0 +1,185 @@
+package com.dogeby.reliccalculator.core.domain.report
+
+import com.dogeby.reliccalculator.core.data.fake.FakeCharacterReportRepository
+import com.dogeby.reliccalculator.core.data.fake.FakeGameRepository
+import com.dogeby.reliccalculator.core.domain.model.CharacterSimpleReport
+import com.dogeby.reliccalculator.core.domain.model.toSimpleRelicRatingReport
+import com.dogeby.reliccalculator.core.model.mihomo.Character
+import com.dogeby.reliccalculator.core.model.mihomo.Element
+import com.dogeby.reliccalculator.core.model.mihomo.LightCone
+import com.dogeby.reliccalculator.core.model.mihomo.Path
+import com.dogeby.reliccalculator.core.model.mihomo.index.RelicInfo
+import com.dogeby.reliccalculator.core.model.mihomo.index.RelicPiece
+import com.dogeby.reliccalculator.core.model.mihomo.index.sampleCharacterInfo
+import com.dogeby.reliccalculator.core.model.mihomo.index.sampleCharacterInfoWithDetails
+import com.dogeby.reliccalculator.core.model.preferences.CharacterSortField
+import com.dogeby.reliccalculator.core.model.preset.Preset
+import com.dogeby.reliccalculator.core.model.report.AffixReport
+import com.dogeby.reliccalculator.core.model.report.CharacterReport
+import com.dogeby.reliccalculator.core.model.report.RelicReport
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.Instant
+import kotlinx.datetime.minus
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class GetCharacterSimpleReportUseCaseTest {
+
+    private lateinit var getCharacterSimpleReportUseCase: GetCharacterSimpleReportUseCase
+    private lateinit var gameRepository: FakeGameRepository
+    private lateinit var characterReportRepository: FakeCharacterReportRepository
+
+    private val characterSample = createCharacterSample()
+    private val relicInfoSample = createRelicInfoSample()
+    private val characterReportSample = createCharacterReportSample()
+
+    @Before
+    fun setUp() {
+        gameRepository = FakeGameRepository()
+        characterReportRepository = FakeCharacterReportRepository()
+
+        getCharacterSimpleReportUseCase = GetCharacterSimpleReportUseCase(
+            characterReportRepository = characterReportRepository,
+            gameRepository = gameRepository,
+        )
+    }
+
+    @Test
+    fun test_getCharacterSimpleReportUseCase_success() = runTest {
+        gameRepository.apply {
+            sendCharacterInfoWithDetailsList(generateSampleCharacterInfoWithDetailsList(3))
+            sendRelicInfoMap(generateRelicInfoMap())
+        }
+
+        val latestCharacterReports = generateLatestCharacterReports(3)
+        val allCharacterReports = latestCharacterReports +
+            generateOldCharacterReports(latestCharacterReports)
+        val expectedCharacterSimpleReports =
+            generateExpectedCharacterSimpleReports(latestCharacterReports)
+
+        characterReportRepository.sendCharacterReports(allCharacterReports)
+
+        val actualCharacterSimpleReports = getCharacterSimpleReportUseCase(
+            filteredRarities = emptySet(),
+            filteredPathIds = emptySet(),
+            filteredElementIds = emptySet(),
+            sortField = CharacterSortField.ID_ASC,
+        ).first()
+
+        Assert.assertEquals(expectedCharacterSimpleReports, actualCharacterSimpleReports)
+    }
+
+    private fun createCharacterSample() = Character(
+        id = "1212",
+        name = "경류",
+        icon = "icon/character/1212.png",
+        preview = "",
+        portrait = "",
+        path = Path("", "", ""),
+        element = Element("", "", ""),
+        lightCone = LightCone("", "", "", ""),
+        relics = emptyList(),
+        relicSets = emptyList(),
+        attributes = emptyList(),
+        additions = emptyList(),
+    )
+
+    private fun createRelicInfoSample() = RelicInfo(
+        id = "1",
+        setId = "104",
+        name = "Hunter's Artaius Hood",
+        rarity = 5,
+        type = RelicPiece.HEAD,
+        maxLevel = 15,
+        mainAffixId = "51",
+        subAffixId = "5",
+        icon = "icon/relic/104_0.png",
+    )
+
+    private fun createCharacterReportSample() = CharacterReport(
+        id = 0,
+        character = characterSample,
+        preset = Preset(
+            characterId = "1212",
+            emptyList(),
+            emptyMap(),
+            emptyList(),
+            attrComparisons = emptyList(),
+        ),
+        score = 5.0f,
+        relicReports = listOf(
+            createRelicReport("1"),
+            createRelicReport("2"),
+        ),
+        attrComparisonReports = emptyList(),
+        validAffixCounts = emptyList(),
+        generationTime = Instant.parse("2024-02-11T00:04:07.553347500Z"),
+    )
+
+    private fun createRelicReport(id: String) = RelicReport(
+        id = id,
+        score = 1f,
+        mainAffixReport = AffixReport(
+            type = "1",
+            score = 1f,
+        ),
+        subAffixReports = List(3) {
+            AffixReport(
+                type = "type$it",
+                score = it.toFloat(),
+            )
+        },
+    )
+
+    private fun generateSampleCharacterInfoWithDetailsList(size: Int) = List(size) {
+        sampleCharacterInfoWithDetails.copy(
+            characterInfo = sampleCharacterInfo.copy(id = "$it"),
+        )
+    }
+
+    private fun generateRelicInfoMap() = mapOf(
+        "1" to relicInfoSample.copy(id = "1"),
+        "2" to relicInfoSample.copy(
+            id = "2",
+            type = RelicPiece.OBJECT,
+        ),
+    )
+
+    private fun generateLatestCharacterReports(size: Int) = List(size) { index ->
+        characterReportSample.copy(
+            id = index,
+            character = characterSample.copy(id = "$index"),
+        )
+    }
+
+    private fun generateOldCharacterReports(reports: List<CharacterReport>) = reports.map {
+        it.copy(
+            generationTime = it.generationTime.minus(1, DateTimeUnit.HOUR),
+        )
+    }
+
+    private fun generateExpectedCharacterSimpleReports(reports: List<CharacterReport>) =
+        reports.map { characterReport ->
+            CharacterSimpleReport(
+                id = characterReport.id,
+                characterId = characterReport.character.id,
+                name = characterSample.name,
+                icon = characterSample.icon,
+                updatedDate = characterReport.generationTime,
+                totalScore = characterReport.score,
+                cavernRelics = listOf(
+                    characterReport.relicReports.first().toSimpleRelicRatingReport(
+                        relicInfoSample.icon,
+                    ),
+                ),
+                planarOrnaments = listOf(
+                    characterReport.relicReports.last().toSimpleRelicRatingReport(
+                        relicInfoSample.icon,
+                    ),
+                ),
+            )
+        }
+}

--- a/core/model/src/main/java/com/dogeby/reliccalculator/core/model/report/CharacterReport.kt
+++ b/core/model/src/main/java/com/dogeby/reliccalculator/core/model/report/CharacterReport.kt
@@ -5,6 +5,7 @@ import com.dogeby.reliccalculator.core.model.preset.Preset
 import kotlinx.datetime.Instant
 
 data class CharacterReport(
+    val id: Int = 0,
     val character: Character,
     val preset: Preset,
     val score: Float,

--- a/core/ui/src/main/java/com/dogeby/reliccalculator/core/ui/component/character/CharacterSimpleReportCard.kt
+++ b/core/ui/src/main/java/com/dogeby/reliccalculator/core/ui/component/character/CharacterSimpleReportCard.kt
@@ -52,6 +52,7 @@ fun CharacterSimpleReportCard(
 }
 
 data class CharacterSimpleReportCardUiState(
+    val id: String,
     val characterName: String,
     val characterIcon: String,
     val updatedDate: Instant,
@@ -65,6 +66,7 @@ private fun PreviewCharacterSimpleReportCard() {
     RelicCalculatorTheme {
         CharacterSimpleReportCard(
             characterSimpleReportCardUiState = CharacterSimpleReportCardUiState(
+                id = "",
                 characterName = "name",
                 characterIcon = "icon/character/1107.png",
                 updatedDate = Clock.System.now(),

--- a/core/ui/src/main/java/com/dogeby/reliccalculator/core/ui/component/character/CharacterSimpleReportCardList.kt
+++ b/core/ui/src/main/java/com/dogeby/reliccalculator/core/ui/component/character/CharacterSimpleReportCardList.kt
@@ -1,0 +1,92 @@
+package com.dogeby.reliccalculator.core.ui.component.character
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyGridScope
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.dogeby.reliccalculator.core.ui.component.relic.CharacterRelicRatingListUiState
+import com.dogeby.reliccalculator.core.ui.component.relic.RelicRatingUiState
+import com.dogeby.reliccalculator.core.ui.theme.RelicCalculatorTheme
+import kotlinx.datetime.Clock
+
+fun LazyGridScope.characterSimpleReportCardList(
+    characterSimpleReportCardListUiState: CharacterSimpleReportCardListUiState,
+    onCardClick: (id: String) -> Unit,
+) {
+    when (characterSimpleReportCardListUiState) {
+        CharacterSimpleReportCardListUiState.Loading -> Unit
+        is CharacterSimpleReportCardListUiState.Success -> {
+            items(
+                items = characterSimpleReportCardListUiState.characterSimpleReportCards,
+                key = { it.id },
+            ) {
+                CharacterSimpleReportCard(
+                    characterSimpleReportCardUiState = it,
+                    modifier = Modifier.clickable {
+                        onCardClick(it.id)
+                    },
+                )
+            }
+        }
+    }
+}
+
+sealed interface CharacterSimpleReportCardListUiState {
+
+    data object Loading : CharacterSimpleReportCardListUiState
+
+    data class Success(
+        val characterSimpleReportCards: List<CharacterSimpleReportCardUiState>,
+    ) : CharacterSimpleReportCardListUiState
+}
+
+@Preview(apiLevel = 33)
+@Composable
+private fun PreviewCharacterSimpleReportCardList() {
+    val characterSimpleReportCards = List(6) {
+        CharacterSimpleReportCardUiState(
+            id = "$it",
+            characterName = "name $it",
+            characterIcon = "icon/character/1107.png",
+            updatedDate = Clock.System.now(),
+            score = 5.0f,
+            characterRelicRatingListUiState = CharacterRelicRatingListUiState.Success(
+                cavernRelics = List(4) {
+                    RelicRatingUiState(
+                        id = "cavernRelics$it",
+                        icon = "icon/relic/311_1.png",
+                        score = 4.5f,
+                    )
+                },
+                planarOrnaments = List(2) {
+                    RelicRatingUiState(
+                        id = "planarOrnaments$it",
+                        icon = "icon/relic/311_1.png",
+                        score = 2f,
+                    )
+                },
+            ),
+        )
+    }
+    RelicCalculatorTheme {
+        LazyVerticalGrid(
+            columns = GridCells.Adaptive(360.dp),
+            contentPadding = PaddingValues(8.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            characterSimpleReportCardList(
+                characterSimpleReportCardListUiState = CharacterSimpleReportCardListUiState
+                    .Success(characterSimpleReportCards),
+                onCardClick = {},
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Description
- Enhancement
  - CharacterSimpleReportCardList 구현
  - CharacterReportDao에 characterIds로 report get 함수, 모든 캐릭터 최근 report get 함수 구현
  - CharacterReportRepository 구현
  - GetCharacterSimpleReportUseCase 구현
- Refactoring
  - CharacterReportEntity에 character, preset 추가
- Fix
  - GetPresetWithDetailsListUseCase의 id 정렬이 거꾸로인 문제 해결
## Issue
- resolved #182
- resolved #184
- resolved #185
- resolved #186
- resolved #187 
- resolved #188