### PR TITLE
Remove items key parameter from presetList and characterSimpleReportC…

### DIFF
--- a/core/ui/src/main/java/com/dogeby/reliccalculator/core/ui/component/character/CharacterSimpleReportCardList.kt
+++ b/core/ui/src/main/java/com/dogeby/reliccalculator/core/ui/component/character/CharacterSimpleReportCardList.kt
@@ -27,7 +27,6 @@ fun LazyGridScope.characterSimpleReportCardList(
         is CharSimpleReportCardListUiState.Success -> {
             items(
                 items = charSimpleReportCardListUiState.characterSimpleReportCards,
-                key = { it.id },
             ) {
                 CharacterSimpleReportCard(
                     charSimpleReportCardUiState = it,

--- a/core/ui/src/main/java/com/dogeby/reliccalculator/core/ui/component/preset/PresetList.kt
+++ b/core/ui/src/main/java/com/dogeby/reliccalculator/core/ui/component/preset/PresetList.kt
@@ -33,7 +33,6 @@ fun LazyGridScope.presetList(
         is PresetListUiState.Success -> {
             items(
                 items = presetListUiState.presets,
-                key = { it.characterId },
             ) { presetWithDetails ->
                 PresetCard(
                     presetWithDetails = presetWithDetails,


### PR DESCRIPTION
- Fix
  - presetList, characterSimpleReportCardList 정렬 시 현재 item을 따라가는게 아니라 스크롤 상태를 유지하게 수정
## Issue
- resolved #206